### PR TITLE
Check for the help option first

### DIFF
--- a/src/Apps/cudaPlanesweepMAPTk.cpp
+++ b/src/Apps/cudaPlanesweepMAPTk.cpp
@@ -154,6 +154,12 @@ int main(int argc, char* argv[])
     boost::program_options::store(boost::program_options::command_line_parser(argc, argv).options(desc).run(), vm);
     boost::program_options::notify(vm);
 
+    if (vm.count("help"))
+    {
+        std::cout << desc << std::endl;
+        return 1;
+    }
+
     //Read the .ply File
     std::vector<Eigen::Vector3d> points;
 
@@ -178,12 +184,6 @@ int main(int argc, char* argv[])
 //    for (int i = 0; i < points.size(); ++i) {
 //      std::cout << points[i] << std::endl;
 //    }
-
-    if (vm.count("help"))
-    {
-        std::cout << desc << std::endl;
-        return 1;
-    }
 
     boost::timer timer,globalTimer;
 


### PR DESCRIPTION
Previously calling the tool with just --help would hang because it would
try to load an invalid landmarks file first.