### PR TITLE
Generalize PLY parser to handle newer PLYs from MAP-Tk

### DIFF
--- a/src/Apps/cudaPlanesweepMAPTk.cpp
+++ b/src/Apps/cudaPlanesweepMAPTk.cpp
@@ -5,6 +5,7 @@
 #include <iostream>
 #include <iomanip>
 #include <fstream>
+#include <sstream>
 #include <vector>
 
 #include <opencv2/highgui/highgui.hpp>
@@ -169,8 +170,11 @@ int main(int argc, char* argv[])
     double x, y, z;
     int id;
 
-    while(landmarksFile >> x >> y >> z >> id)
+    std::string line;
+    while(std::getline(landmarksFile, line))
     {
+      std::stringstream ss(line);
+      ss >> x >> y >> z;
       points.push_back(Eigen::Vector3d(x,y,z));
     }
 


### PR DESCRIPTION
PLY files from newer versions of MAP-Tk have more fields than X,Y,Z,id
as was assumed by this parsing code.  However X,Y,Z are still the first
fields on each line.  This change reads the file line by line and then
extracts X,Y,Z from the start of each line.